### PR TITLE
Add protocol handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.dec
 *.swp
+.vscode

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ or
 helm gsm -f path/to/secrets.yaml
 ```
 
+Or alternatively use inline as a protocol handler - eg.
+```
+helm template -f gsm://path/to/secrets.yaml .
+```
+
 The secrets file needs to have a very specific format:
 ```
 secrets:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,3 +9,7 @@ platformCommand:
   - os: darwin
     arch: amd64
     command: "$HELM_PLUGIN_DIR/bin/helm-gsm-darwin"
+downloaders:
+  - command: "scripts/protocol-handler.sh"
+    protocols:
+      - "gsm"

--- a/scripts/protocol-handler.sh
+++ b/scripts/protocol-handler.sh
@@ -2,7 +2,12 @@
 
 set -euf
 
-decrypt_command="$HELM_PLUGIN_DIR/bin/helm-gsm-linux -f"
+os=$(uname)
+binary="helm-gsm-linux"
+if [ "$os" = "Darwin" ]; then
+  binary="helm-gsm-darwin"
+fi
+decrypt_command="$HELM_PLUGIN_DIR/bin/$binary -f"
 
 # https://helm.sh/docs/topics/plugins/#downloader-plugins
 # It's always the 4th parameter

--- a/scripts/protocol-handler.sh
+++ b/scripts/protocol-handler.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -euf
+
+decrypt_command="$HELM_PLUGIN_DIR/bin/helm-gsm-linux -f"
+
+# https://helm.sh/docs/topics/plugins/#downloader-plugins
+# It's always the 4th parameter
+file=$(printf '%s' "${4}" | sed -E -e 's!gsm://!!')
+
+# send output to /dev/null so it doesn't break helm
+$decrypt_command ${file} > /dev/null
+real_file="${file}.dec"
+
+cat "${real_file}"


### PR DESCRIPTION
Allows you to specify the file to be decrypted as part of a regular helm command, eg. `helm template` or `helm upgrade`.

For example:

```helm upgrade web -f gsm://environments/test/secrets.yml .```